### PR TITLE
fix chrome memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -879,14 +879,15 @@ const sleepingTime = sleepingTimeInMinutes * 60000;
                 })
 
                 await page.waitForTimeout(5000);
-                await page.evaluate(async function () {
-                    await SM.Logout();
-                        }).catch(async function(){ 
+                await browsers[0].close();
+                //await page.evaluate(async function () {
+                    //await SM.Logout();
+                       // }).catch(async function(){ 
                             //const pages =  browsers[0].pages();
                             //await Promise.all(pages.map(page =>page.close()));
-                            await browsers[0].close();
-                            await browsers[0].process().kill('SIGKILL'); 
-                        })
+                            //await browsers[0].close();
+                            //await browsers[0].process().kill('SIGKILL'); 
+                        //})
             }
             let endTimer = new Date().getTime();
 			let totalTime = endTimer - startTimer;


### PR DESCRIPTION
fixed the memory leak due to chrome instances not being closed

The bot was opening a chrome instance every time it fights a battle, but was not closing. In some hours would result in out of memory (even on a 24gb machine). this commit fix it, now the instances are being closed and the memory usage are as low as < 1GB